### PR TITLE
Add self-destroying service worker to unstick returning visitors

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+// Self-destroying service worker.
+// Replaces the old gatsby-plugin-offline worker that some returning visitors
+// still have installed from before this site started redirecting to
+// veronicalee.vercel.app. That old worker answers navigation requests from
+// its own cache instead of hitting the network, so it never sees the
+// redirect. This version installs in its place, clears the old caches,
+// unregisters itself, and reloads open tabs so they fetch the real page.
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+      .then(() => self.registration.unregister())
+      .then(() => self.clients.matchAll({ type: 'window' }))
+      .then((clients) => clients.forEach((client) => client.navigate(client.url)))
+  );
+});


### PR DESCRIPTION
## Summary
- Returning visitors who loaded the site before the vercel redirect went live still have the old `gatsby-plugin-offline` service worker installed, which answers navigation requests from its own cache instead of the network — so they never see the redirect and it looks like a caching bug that only hard refresh or incognito fixes.
- Since `sw.js` was deleted when the redirect shipped (#2), the old worker has nothing to update against and stays stuck indefinitely.
- This redeploys `sw.js` as a kill switch: the old app shell's own JS still calls `navigator.serviceWorker.register('/sw.js')` on every load, so returning browsers will pick up this new version, install it in place of the old one, clear its caches, unregister itself, and reload open tabs — landing them on a normal network fetch of the real (redirecting) `index.html`.

## Test plan
- [ ] After merge, confirm `curl -s https://leeveronica.github.io/sw.js` serves this kill-switch content
- [ ] In Chrome DevTools → Application → Service Workers, verify the new worker installs/activates and unregisters itself
- [ ] Check back with a previously-cached browser after ~24h to confirm it now redirects without a hard refresh
- [ ] Leave `sw.js` in place for a few weeks to catch stragglers, then it can be removed as cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)