### PR TITLE
Add CLAUDE.md documenting branch roles and PR-only workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Working in this repo
+
+- `source` = the actual Gatsby project (default branch). `main` = deploy output that GitHub Pages serves; historically overwritten by `npm run deploy` (`gh-pages -d public`), but the redirect/service-worker fix lives there as hand-written files now.
+- Both `main` and `source` have GitHub branch protection requiring a PR + 1 approval, enforced even for admins (`enforce_admins: true`). Never push directly to either branch — always create a feature branch, open a PR with `gh pr create`, and let the user review/merge it. Don't try to self-merge with `--admin`; it will be rejected, and even if it weren't, the user should approve before it lands.


### PR DESCRIPTION
## Summary
- Documents that `source` is the Gatsby project (default branch) and `main` is the deploy output GitHub Pages serves.
- Notes both branches now require PR + approval, enforced even for admins, so future direct pushes should not be attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)